### PR TITLE
Update build.gradle to suppor new vesrion of "com.facebook.android:au…

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -27,6 +27,6 @@ repositories {
 dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation "com.android.support:recyclerview-v7:${safeExtGet('supportLibVersion', '26.1.0')}"
-    implementation 'com.facebook.android:audience-network-sdk:6.2.+'
+    implementation 'com.facebook.android:audience-network-sdk:6.+'
     implementation 'com.facebook.android:facebook-android-sdk:6.+'
 }


### PR DESCRIPTION
…dience-network-sdk:6.+"

this  fixed [issue #322](https://github.com/callstack/react-native-fbads/issues/322)

Based on facebook documentation:
https://developers.facebook.com/docs/audience-network/setting-up/platform-setup/android/add-sdk